### PR TITLE
Changed approach in processing Tag, further details in comments

### DIFF
--- a/public/pvsioweb/lib/statemachine/stateMachine.js
+++ b/public/pvsioweb/lib/statemachine/stateMachine.js
@@ -1382,7 +1382,7 @@ module.exports = {
     restoreGraph : restoreGraph,
     buildGraph : buildGraph,
     add_node : function(x,y,label,writer) { var ret = add_node(x,y,label,writer);  return ret; },
-    add_edge : function(source, target, lab, notWr) {add_edge(source, target, lab, notWr);  },
+    add_edge : function(source, target, lab, notWr) { return add_edge(source, target, lab, notWr);  },
     emulink: emulink,
     clearSvg : clearSvg,
 	highlightElements: highlightElements,

--- a/public/pvsioweb/lib/statemachine/stateToPvsSpecificationWriter.js
+++ b/public/pvsioweb/lib/statemachine/stateToPvsSpecificationWriter.js
@@ -402,6 +402,8 @@ function WriterOnContent( editor)
     this.tagFieldStart = "  " + this.BLOCK_START + ", " + this.ID_FIELD + " : \"State\", \"_type\": \"State\"}";
     this.tagFieldEnd = "  " + this.BLOCK_END + ", " + this.ID_FIELD + " : \"State\", \"_type\": \"State\"}";
 
+    this.tagSwitchCond = "{\"_cond\" : \"*COND*\"}";
+
     /********* Functions about Editor changing (Note: I need to define them here ********/
     
     this.handleUserModificationOnEditor = function()
@@ -637,6 +639,8 @@ function WriterOnContent( editor)
     this.addSwitchCond = function(nameTrans, sourceName, targetName, cond)
     {
         var arrayTag = this.buildTagCond(nameTrans, sourceName, targetName);
+        var arrayTagCopy = arrayTag;
+
         arrayTag[0] = arrayTag[0].replace(/(\r\n|\n|\r)/gm, "");
         arrayTag[1] = arrayTag[1].replace(/(\r\n|\n|\r)/gm, "");
         var content = this.getContentBetweenTags(arrayTag[0], arrayTag[1], false);
@@ -651,8 +655,19 @@ function WriterOnContent( editor)
             content.substring(content.indexOf("->") -2) ;
         
         this.editor.find(content );
-        this.editor.replace( newContent );      
+        this.editor.replace( newContent );     
+
+        this.addSwitchCondInTag(arrayTagCopy[0], arrayTagCopy[1], cond); 
         
+    }
+    this.addSwitchCondInTag = function(startTag, endTag, cond)
+    {
+        var newStartTag = startTag + this.tagSwitchCond.replace("*COND*", cond);
+        var newEndTag = endTag + this.tagSwitchCond.replace("*COND*", cond);
+        this.editor.find(startTag);
+        this.editor.replace(newStartTag); 
+        this.editor.find(endTag);
+        this.editor.replace(newEndTag);
     }
     this.getContentBetweenTags = function(startTag, endTag, isRegexp)
     {


### PR DESCRIPTION
In this new version of parserSpecification.js I've changed approach in processing tag:

In old version we processed string tag looking for fields using function like 'substring()' 'indexOf()' .

Now, we transform a string like:

%{"_block" : "BlockStart", "_id" : "  tick", "   _source" : "  X0", "_target" : "X1", "_type": "Transition"}

in an object using JSON.parse(); this way we can get properties in an easier way, also deleting space both in keys and values we avoid problems which we had .
Example:
var initialTag = %{"_block" : "BlockStart", "_id" : "  tick", "   _source" : "  X0", "_target" : "X1", "_type": "Transition"};
var stringJson = initialTag.substring(initialTag.indexOf('{') );
var objectBlock = JSON.parse(stringJson);  
objectBlock = this.transformKeyAndValueAvoidingSpaces(objectBlock);
var source = objectBlock._source;
var target = objectBlock._target;
..

Note that this way we can add properties in the tag in an easy way.

In this commit there is also some code about parsing switch conditions, please don't look at that, I have to change that implementation properly to this new approach.
