### PR TITLE
fix for issue #129

### DIFF
--- a/src/client/lib/cm/mode/pvs/pvs.js
+++ b/src/client/lib/cm/mode/pvs/pvs.js
@@ -39,7 +39,7 @@
         function stringTokenizer(quote) {
             return function (stream, state) {
                 var escaped = false, next, end = false;
-                while((next = stream.next()) !== null) {
+                while((next = stream.next()) != null) {
                     if (next === quote && !escaped) {
                         end = true;
                         break;


### PR DESCRIPTION
```
editor no longer freezes when typing quote characters
```
